### PR TITLE
Add rotation property on objects

### DIFF
--- a/src/TmxObject.cpp
+++ b/src/TmxObject.cpp
@@ -42,6 +42,7 @@ namespace Tmx
         , width(0)
         , height(0)
         , gid(0)
+        , rotation(0.0)
         , ellipse(0)
         , polygon(0)
         , polyline(0)
@@ -83,6 +84,7 @@ namespace Tmx
         objectElem->Attribute("width", &width);
         objectElem->Attribute("height", &height);
         objectElem->Attribute("gid", &gid);
+        objectElem->Attribute("rotation", &rotation);
 
         // Read the ellipse of the object if there are any.
         const TiXmlNode *ellipseNode = objectNode->FirstChild("ellipse");

--- a/src/TmxObject.h
+++ b/src/TmxObject.h
@@ -69,6 +69,9 @@ namespace Tmx
         // Get the height of the object, in pixels.
         int GetHeight() const { return height; }
 
+        // Get the rotation of the object, in degrees.
+        double GetRot() const { return rotation; }
+
         // Get the Global ID of the tile associated with this object.
         int GetGid() const { return gid; }
 
@@ -93,6 +96,8 @@ namespace Tmx
         int width;
         int height;
         int gid;
+
+        double rotation;
 
         Tmx::Ellipse *ellipse;
         Tmx::Polygon *polygon;


### PR DESCRIPTION
Newer versions of Tiled support object rotation. Here's a pretty simple patch to support the rotation property.
