### PR TITLE
Add support for <image> in <tile>

### DIFF
--- a/src/TmxMap.h
+++ b/src/TmxMap.h
@@ -124,12 +124,12 @@ namespace Tmx
         // Read a file and parse it.
         // Note: use '/' instead of '\\' as it is using '/' to find the path.
         void ParseFile(const std::string &fileName);
-        
+
         // Parse text containing TMX formatted XML.
         void ParseText(const std::string &text);
 
         // Get the filename used to read the map.
-        const std::string &GetFilename() { return file_name; }
+        const std::string &GetFilename() const { return file_name; }
 
         // Get a path to the directory of the map file if any.
         const std::string &GetFilepath() const { return file_path; }

--- a/src/TmxTile.cpp
+++ b/src/TmxTile.cpp
@@ -33,16 +33,21 @@
 namespace Tmx
 {
     Tile::Tile() :
-            id(0), properties(), isAnimated(false),hasObjects(false), totalDuration(0)
+            id(0), properties(), isAnimated(false),hasObjects(false), totalDuration(0), image(NULL)
     {
     }
     Tile::Tile(int id) :
-            id(id), properties(), isAnimated(false),hasObjects(false), totalDuration(0)
+            id(id), properties(), isAnimated(false),hasObjects(false), totalDuration(0), image(NULL)
     {
     }
 
     Tile::~Tile()
     {
+        if(image)
+        {
+            delete image;
+            image = NULL;
+        }
     }
 
     void Tile::Parse(const tinyxml2::XMLNode *tileNode)
@@ -111,6 +116,13 @@ namespace Tmx
 
                 objectNode = objectNode->NextSiblingElement("object");
             }
+        }
+
+        const tinyxml2::XMLNode *imageNode = tileNode->FirstChildElement("image");
+        if(imageNode)
+        {
+            image = new Image();
+            image->Parse(imageNode);
         }
 
     }

--- a/src/TmxTile.h
+++ b/src/TmxTile.h
@@ -26,6 +26,7 @@
 #include <vector>
 
 #include "TmxPropertySet.h"
+#include "TmxImage.h"
 
 namespace tinyxml2
 {
@@ -79,6 +80,11 @@ namespace Tmx
             return totalDuration;
         }
 
+        const Tmx::Image* GetImage() const
+        {
+            return image;
+        }
+
         // Returns the frames of the animation.
         const std::vector<AnimationFrame> &GetFrames() const
         {
@@ -125,6 +131,7 @@ namespace Tmx
         std::vector<Tmx::Object*> objects;
         unsigned int totalDuration;
         std::vector<AnimationFrame> frames;
+        Tmx::Image* image;
     };
 
     //-------------------------------------------------------------------------


### PR DESCRIPTION
Tiled supports building tilesets from a sequence of separate images. Then every `<tile>` tag contains `<image>` tag describing the image used for that tile. I added support for this data, by almost entirely copying existing code parsing `<image>` tag in `<tileset>`.
