### PR TITLE
Removed const return types

### DIFF
--- a/src/TmxImageLayer.cpp
+++ b/src/TmxImageLayer.cpp
@@ -23,6 +23,7 @@
 //-----------------------------------------------------------------------------
 #include <tinyxml2.h>
 #include <cstdlib>
+#include <cassert> //RJCB
 
 #include "TmxLayer.h"
 #include "TmxImageLayer.h"
@@ -59,6 +60,7 @@ namespace Tmx
 
         // Parse the image.
         const tinyxml2::XMLNode *imageNode = imageLayerElem->FirstChildElement("image");
+        assert(imageNode); //RJCB
         
         if (imageNode) 
         {

--- a/src/TmxTile.h
+++ b/src/TmxTile.h
@@ -92,13 +92,13 @@ namespace Tmx
         }
 
         // Get set of Collision Objects
-        const std::vector<Tmx::Object*> GetObjects() const
+        std::vector<Tmx::Object*> GetObjects() const
         {
             return objects;
         }
 
         // Returns true if tile has Collision Objects
-        const bool HasObjects() const
+        bool HasObjects() const
         {
             return hasObjects;
         }

--- a/src/TmxTileset.cpp
+++ b/src/TmxTileset.cpp
@@ -26,6 +26,7 @@
 // Author: Tamir Atias
 //-----------------------------------------------------------------------------
 #include <tinyxml2.h>
+#include <cassert> //RJCB
 
 #include "TmxTileset.h"
 #include "TmxTileOffset.h"
@@ -125,6 +126,8 @@ namespace Tmx
 
             // Update node and element references to the new node
             tilesetNode = tileset_doc.FirstChildElement("tileset");
+            assert(tilesetNode); //RJCB
+
             tilesetElem = tilesetNode->ToElement();
         }
 
@@ -152,7 +155,7 @@ namespace Tmx
 
         // Parse the image.
         const tinyxml2::XMLNode *imageNode = tilesetNode->FirstChildElement("image");
-        if (imageNode) 
+        if (imageNode)
         {
             image = new Image();
             image->Parse(imageNode);


### PR DESCRIPTION
I am happy to see the use of const in as much places as possible. 

Too bad, returning a `const bool` triggers a warning by the `-weffc++` flag under GCC, named after reference [1], even if the advice is to use const whenever possible. Scott's newer book, Modern C++11, suggests to abandon constant return types as these may hamper move semantics. Returning a `const std::vector<T*>` (note: you can still modify a `T*`!) or `const std::vector<T>` appears to be pre-C++11 by Scott, but already advised against by Lakos [2].

Keep up the good job!
## References

[1] Scott Meyers. Effective C++ (3rd edition).ISBN: 0-321-33487-6. Item 3: 'Use const whenever possible'
[1] John Lakos. Large-Scale C++ Software Design. 1996. ISBN: 0-201-63362-0. Chapter 9.1.9: 'Avoid declaring results returned by value from functions as const'
