### PR TITLE
Add support for typed properties

### DIFF
--- a/src/TmxProperty.cpp
+++ b/src/TmxProperty.cpp
@@ -1,0 +1,85 @@
+//-----------------------------------------------------------------------------
+// TmxProperty.cpp
+//
+// Copyright (c) 2016, Tamir Atias
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL TAMIR ATIAS BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Author: Tamir Atias
+//-----------------------------------------------------------------------------
+#include <tinyxml2.h>
+
+#include "TmxProperty.h"
+
+namespace Tmx
+{
+	Property::Property()
+		: type(TMX_PROPERTY_STRING)
+	{
+	}
+
+	void Property::Parse(const tinyxml2::XMLElement *propertyElem)
+	{
+		auto typeAttribute = propertyElem->FindAttribute("type");
+
+		if (typeAttribute != nullptr)
+		{
+			auto typeAsCString = typeAttribute->Value();
+
+			if (strcmp(typeAsCString, "string") == 0)
+			{
+				type = TMX_PROPERTY_STRING;
+			}
+			else if (strcmp(typeAsCString, "bool") == 0)
+			{
+				type = TMX_PROPERTY_BOOL;
+			}
+			else if (strcmp(typeAsCString, "float") == 0)
+			{
+				type = TMX_PROPERTY_FLOAT;
+			}
+			else if (strcmp(typeAsCString, "int") == 0)
+			{
+				type = TMX_PROPERTY_INT;
+			}
+			else
+			{
+				type = TMX_PROPERTY_STRING;
+			}
+		}
+		else
+		{
+			type = TMX_PROPERTY_STRING;
+		}
+
+		auto valueAsCString = propertyElem->Attribute("value");
+		if (valueAsCString)
+		{
+		    value = valueAsCString;
+		}
+		else
+		{
+		    // The value of properties that contain newlines is stored in the element text.
+		    valueAsCString = propertyElem->GetText();
+		    value = valueAsCString ? valueAsCString : std::string(); 
+		}
+	}
+}

--- a/src/TmxProperty.cpp
+++ b/src/TmxProperty.cpp
@@ -31,55 +31,55 @@
 
 namespace Tmx
 {
-	Property::Property()
-		: type(TMX_PROPERTY_STRING)
-	{
-	}
+    Property::Property()
+        : type(TMX_PROPERTY_STRING)
+    {
+    }
 
-	void Property::Parse(const tinyxml2::XMLElement *propertyElem)
-	{
-		auto typeAttribute = propertyElem->FindAttribute("type");
+    void Property::Parse(const tinyxml2::XMLElement *propertyElem)
+    {
+        auto typeAttribute = propertyElem->FindAttribute("type");
 
-		if (typeAttribute != nullptr)
-		{
-			auto typeAsCString = typeAttribute->Value();
+        if (typeAttribute != nullptr)
+        {
+            auto typeAsCString = typeAttribute->Value();
 
-			if (strcmp(typeAsCString, "string") == 0)
-			{
-				type = TMX_PROPERTY_STRING;
-			}
-			else if (strcmp(typeAsCString, "bool") == 0)
-			{
-				type = TMX_PROPERTY_BOOL;
-			}
-			else if (strcmp(typeAsCString, "float") == 0)
-			{
-				type = TMX_PROPERTY_FLOAT;
-			}
-			else if (strcmp(typeAsCString, "int") == 0)
-			{
-				type = TMX_PROPERTY_INT;
-			}
-			else
-			{
-				type = TMX_PROPERTY_STRING;
-			}
-		}
-		else
-		{
-			type = TMX_PROPERTY_STRING;
-		}
+            if (strcmp(typeAsCString, "string") == 0)
+            {
+                type = TMX_PROPERTY_STRING;
+            }
+            else if (strcmp(typeAsCString, "bool") == 0)
+            {
+                type = TMX_PROPERTY_BOOL;
+            }
+            else if (strcmp(typeAsCString, "float") == 0)
+            {
+                type = TMX_PROPERTY_FLOAT;
+            }
+            else if (strcmp(typeAsCString, "int") == 0)
+            {
+                type = TMX_PROPERTY_INT;
+            }
+            else
+            {
+                type = TMX_PROPERTY_STRING;
+            }
+        }
+        else
+        {
+            type = TMX_PROPERTY_STRING;
+        }
 
-		auto valueAsCString = propertyElem->Attribute("value");
-		if (valueAsCString)
-		{
-		    value = valueAsCString;
-		}
-		else
-		{
-		    // The value of properties that contain newlines is stored in the element text.
-		    valueAsCString = propertyElem->GetText();
-		    value = valueAsCString ? valueAsCString : std::string(); 
-		}
-	}
+        auto valueAsCString = propertyElem->Attribute("value");
+        if (valueAsCString)
+        {
+            value = valueAsCString;
+        }
+        else
+        {
+            // The value of properties that contain newlines is stored in the element text.
+            valueAsCString = propertyElem->GetText();
+            value = valueAsCString ? valueAsCString : std::string(); 
+        }
+    }
 }

--- a/src/TmxProperty.h
+++ b/src/TmxProperty.h
@@ -1,0 +1,116 @@
+//-----------------------------------------------------------------------------
+// TmxProperty.h
+//
+// Copyright (c) 2016, Tamir Atias
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL TAMIR ATIAS BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Author: Tamir Atias
+//-----------------------------------------------------------------------------
+#pragma once
+
+#include <string>
+
+namespace tinyxml2 {
+	class XMLElement;
+}
+
+namespace Tmx
+{
+	//-------------------------------------------------------------------------
+	// The type of a property.
+	//-------------------------------------------------------------------------
+	enum PropertyType
+	{
+		// A string property (default)
+		TMX_PROPERTY_STRING,
+
+		// A boolean property
+		TMX_PROPERTY_BOOL,
+
+		// An integer property
+		TMX_PROPERTY_INT,
+
+		// A floating point property
+		TMX_PROPERTY_FLOAT,
+	};
+
+	//-------------------------------------------------------------------------
+	// Used to store a (typed) property.
+	//-------------------------------------------------------------------------
+	class Property
+	{
+	public:
+		Property();
+
+		// Parse the property element.
+		void Parse(const tinyxml2::XMLElement *propertyElem);
+
+		// Get the type of the property (default: TMX_PROPERTY_STRING)
+		PropertyType GetType() const { return type; }
+
+		// Check if the property is of a certain type.
+		bool IsOfType(PropertyType type) const { return GetType() == type; }
+
+		// Return the value of the property.
+		const std::string &GetValue() const { return value; }
+
+		// Return whether the value is empty or was not specified.
+		bool IsValueEmpty() const { return value.empty(); }
+
+		// Convert the value to a boolean and return it (or the default value if not a boolean.)
+		bool GetBoolValue(bool defaultValue = false) const;
+
+		// Convert the value to an integer and return it (or the default value if not an integer).
+		int GetIntValue(int defaultValue = 0) const;
+
+		// Convert the value to a float and return it (or the default value if not a float).
+		float GetFloatValue(float defaultValue = 0.0f) const;
+
+	private:
+		PropertyType type;
+		std::string value;
+	};
+
+	inline bool Property::GetBoolValue(bool defaultValue) const
+	{
+		if (!IsOfType(TMX_PROPERTY_BOOL))
+			return defaultValue;
+
+		return value.compare("true") == 0;
+	}
+
+	inline int Property::GetIntValue(int defaultValue) const
+	{
+		if (!IsOfType(TMX_PROPERTY_INT))
+			return defaultValue;
+
+		return std::stoi(value);
+	}
+
+	inline float Property::GetFloatValue(float defaultValue) const
+	{
+		if (!IsOfType(TMX_PROPERTY_FLOAT))
+			return defaultValue;
+
+		return std::stof(value);
+	}
+}

--- a/src/TmxProperty.h
+++ b/src/TmxProperty.h
@@ -30,87 +30,87 @@
 #include <string>
 
 namespace tinyxml2 {
-	class XMLElement;
+    class XMLElement;
 }
 
 namespace Tmx
 {
-	//-------------------------------------------------------------------------
-	// The type of a property.
-	//-------------------------------------------------------------------------
-	enum PropertyType
-	{
-		// A string property (default)
-		TMX_PROPERTY_STRING,
+    //-------------------------------------------------------------------------
+    // The type of a property.
+    //-------------------------------------------------------------------------
+    enum PropertyType
+    {
+        // A string property (default)
+        TMX_PROPERTY_STRING,
 
-		// A boolean property
-		TMX_PROPERTY_BOOL,
+        // A boolean property
+        TMX_PROPERTY_BOOL,
 
-		// An integer property
-		TMX_PROPERTY_INT,
+        // An integer property
+        TMX_PROPERTY_INT,
 
-		// A floating point property
-		TMX_PROPERTY_FLOAT,
-	};
+        // A floating point property
+        TMX_PROPERTY_FLOAT,
+    };
 
-	//-------------------------------------------------------------------------
-	// Used to store a (typed) property.
-	//-------------------------------------------------------------------------
-	class Property
-	{
-	public:
-		Property();
+    //-------------------------------------------------------------------------
+    // Used to store a (typed) property.
+    //-------------------------------------------------------------------------
+    class Property
+    {
+    public:
+        Property();
 
-		// Parse the property element.
-		void Parse(const tinyxml2::XMLElement *propertyElem);
+        // Parse the property element.
+        void Parse(const tinyxml2::XMLElement *propertyElem);
 
-		// Get the type of the property (default: TMX_PROPERTY_STRING)
-		PropertyType GetType() const { return type; }
+        // Get the type of the property (default: TMX_PROPERTY_STRING)
+        PropertyType GetType() const { return type; }
 
-		// Check if the property is of a certain type.
-		bool IsOfType(PropertyType type) const { return GetType() == type; }
+        // Check if the property is of a certain type.
+        bool IsOfType(PropertyType type) const { return GetType() == type; }
 
-		// Return the value of the property.
-		const std::string &GetValue() const { return value; }
+        // Return the value of the property.
+        const std::string &GetValue() const { return value; }
 
-		// Return whether the value is empty or was not specified.
-		bool IsValueEmpty() const { return value.empty(); }
+        // Return whether the value is empty or was not specified.
+        bool IsValueEmpty() const { return value.empty(); }
 
-		// Convert the value to a boolean and return it (or the default value if not a boolean.)
-		bool GetBoolValue(bool defaultValue = false) const;
+        // Convert the value to a boolean and return it (or the default value if not a boolean.)
+        bool GetBoolValue(bool defaultValue = false) const;
 
-		// Convert the value to an integer and return it (or the default value if not an integer).
-		int GetIntValue(int defaultValue = 0) const;
+        // Convert the value to an integer and return it (or the default value if not an integer).
+        int GetIntValue(int defaultValue = 0) const;
 
-		// Convert the value to a float and return it (or the default value if not a float).
-		float GetFloatValue(float defaultValue = 0.0f) const;
+        // Convert the value to a float and return it (or the default value if not a float).
+        float GetFloatValue(float defaultValue = 0.0f) const;
 
-	private:
-		PropertyType type;
-		std::string value;
-	};
+    private:
+        PropertyType type;
+        std::string value;
+    };
 
-	inline bool Property::GetBoolValue(bool defaultValue) const
-	{
-		if (!IsOfType(TMX_PROPERTY_BOOL))
-			return defaultValue;
+    inline bool Property::GetBoolValue(bool defaultValue) const
+    {
+        if (!IsOfType(TMX_PROPERTY_BOOL))
+            return defaultValue;
 
-		return value.compare("true") == 0;
-	}
+        return value.compare("true") == 0;
+    }
 
-	inline int Property::GetIntValue(int defaultValue) const
-	{
-		if (!IsOfType(TMX_PROPERTY_INT))
-			return defaultValue;
+    inline int Property::GetIntValue(int defaultValue) const
+    {
+        if (!IsOfType(TMX_PROPERTY_INT))
+            return defaultValue;
 
-		return std::stoi(value);
-	}
+        return std::stoi(value);
+    }
 
-	inline float Property::GetFloatValue(float defaultValue) const
-	{
-		if (!IsOfType(TMX_PROPERTY_FLOAT))
-			return defaultValue;
+    inline float Property::GetFloatValue(float defaultValue) const
+    {
+        if (!IsOfType(TMX_PROPERTY_FLOAT))
+            return defaultValue;
 
-		return std::stof(value);
-	}
+        return std::stof(value);
+    }
 }

--- a/src/TmxPropertySet.cpp
+++ b/src/TmxPropertySet.cpp
@@ -48,17 +48,23 @@ namespace Tmx
     {
         // Iterate through all of the property nodes.
         const tinyxml2::XMLNode *propertyNode = propertiesNode->FirstChildElement("property");
-        string propertyName;
-        string propertyValue;
 
         while (propertyNode)
         {
             const tinyxml2::XMLElement* propertyElem = propertyNode->ToElement();
 
+			auto nameAttrib = propertyElem->FindAttribute("name");
+
+			if (nameAttrib == nullptr || nameAttrib->Value()[0] == 0)
+			{
+				propertyNode = propertyNode->NextSiblingElement("property");
+				continue;
+			}
+
             // Read the attributes of the property and add it to the map
-            propertyName = string(propertyElem->Attribute("name"));
-            propertyValue = string(propertyElem->Attribute("value"));
-            properties[propertyName] = propertyValue;
+			Property property;
+			property.Parse(propertyElem);
+            properties[nameAttrib->Value()] = property;
 
             //propertyNode = propertiesNode->IterateChildren("property", propertyNode); FIXME MAYBE
             propertyNode = propertyNode->NextSiblingElement("property");
@@ -67,30 +73,65 @@ namespace Tmx
 
     string PropertySet::GetStringProperty(const string &name) const
     {
-        map< string, string >::const_iterator iter = properties.find(name);
+        std::unordered_map< string, Property >::const_iterator iter = properties.find(name);
 
         if (iter == properties.end())
             return std::string();
 
-        return iter->second;
+        return iter->second.GetValue();
     }
 
     int PropertySet::GetIntProperty(const string &name, int defaultValue) const
     {
-        std::string str = GetStringProperty(name);
-        return (str.size() == 0) ? defaultValue : atoi(GetStringProperty(name).c_str());
+		auto iter = properties.find(name);
+
+		if (iter == properties.end() || iter->second.IsValueEmpty())
+			return defaultValue;
+
+		// Note that we convert the value here ourselves in order to maintain
+		// compatibility with older versions of the TMX spec.
+		return std::stoi(iter->second.GetValue());
     }
 
     float PropertySet::GetFloatProperty(const string &name, float defaultValue) const
     {
-        std::string str = GetStringProperty(name);
-        return (str.size() == 0) ? defaultValue : atof(GetStringProperty(name).c_str());
+		auto iter = properties.find(name);
+
+		if (iter == properties.end() || iter->second.IsValueEmpty())
+			return defaultValue;
+
+		// Note that we convert the value here ourselves in order to maintain
+		// compatibility with older versions of the TMX spec.
+		return std::stof(iter->second.GetValue());
     }
+
+	bool PropertySet::GetBoolProperty(const string &name, bool defaultValue) const
+	{
+		auto iter = properties.find(name);
+
+		if (iter == properties.end() || iter->second.IsValueEmpty())
+			return defaultValue;
+
+		// Note that we convert the value here ourselves in order to maintain
+		// compatibility with older versions of the TMX spec.
+		return iter->second.GetValue().compare("true") == 0;
+	}
 
     bool PropertySet::HasProperty( const string& name ) const
     {
         if( properties.empty() ) return false;
         return ( properties.find(name) != properties.end() );
     }
+
+	std::map< std::string, std::string > PropertySet::GetList() const
+	{
+		std::map< std::string, std::string > orderedProperties;
+		for (auto &pair : properties)
+		{
+			auto &property = pair.second;
+			orderedProperties[pair.first] = property.GetValue();
+		}
+		return orderedProperties;
+	}
 
 }

--- a/src/TmxPropertySet.cpp
+++ b/src/TmxPropertySet.cpp
@@ -53,17 +53,17 @@ namespace Tmx
         {
             const tinyxml2::XMLElement* propertyElem = propertyNode->ToElement();
 
-			auto nameAttrib = propertyElem->FindAttribute("name");
+            auto nameAttrib = propertyElem->FindAttribute("name");
 
-			if (nameAttrib == nullptr || nameAttrib->Value()[0] == 0)
-			{
-				propertyNode = propertyNode->NextSiblingElement("property");
-				continue;
-			}
+            if (nameAttrib == nullptr || nameAttrib->Value()[0] == 0)
+            {
+                propertyNode = propertyNode->NextSiblingElement("property");
+                continue;
+            }
 
             // Read the attributes of the property and add it to the map
-			Property property;
-			property.Parse(propertyElem);
+            Property property;
+            property.Parse(propertyElem);
             properties[nameAttrib->Value()] = property;
 
             //propertyNode = propertiesNode->IterateChildren("property", propertyNode); FIXME MAYBE
@@ -83,39 +83,39 @@ namespace Tmx
 
     int PropertySet::GetIntProperty(const string &name, int defaultValue) const
     {
-		auto iter = properties.find(name);
+        auto iter = properties.find(name);
 
-		if (iter == properties.end() || iter->second.IsValueEmpty())
-			return defaultValue;
+        if (iter == properties.end() || iter->second.IsValueEmpty())
+            return defaultValue;
 
-		// Note that we convert the value here ourselves in order to maintain
-		// compatibility with older versions of the TMX spec.
-		return std::stoi(iter->second.GetValue());
+        // Note that we convert the value here ourselves in order to maintain
+        // compatibility with older versions of the TMX spec.
+        return std::stoi(iter->second.GetValue());
     }
 
     float PropertySet::GetFloatProperty(const string &name, float defaultValue) const
     {
-		auto iter = properties.find(name);
+        auto iter = properties.find(name);
 
-		if (iter == properties.end() || iter->second.IsValueEmpty())
-			return defaultValue;
+        if (iter == properties.end() || iter->second.IsValueEmpty())
+            return defaultValue;
 
-		// Note that we convert the value here ourselves in order to maintain
-		// compatibility with older versions of the TMX spec.
-		return std::stof(iter->second.GetValue());
+        // Note that we convert the value here ourselves in order to maintain
+        // compatibility with older versions of the TMX spec.
+        return std::stof(iter->second.GetValue());
     }
 
-	bool PropertySet::GetBoolProperty(const string &name, bool defaultValue) const
-	{
-		auto iter = properties.find(name);
+    bool PropertySet::GetBoolProperty(const string &name, bool defaultValue) const
+    {
+        auto iter = properties.find(name);
 
-		if (iter == properties.end() || iter->second.IsValueEmpty())
-			return defaultValue;
+        if (iter == properties.end() || iter->second.IsValueEmpty())
+            return defaultValue;
 
-		// Note that we convert the value here ourselves in order to maintain
-		// compatibility with older versions of the TMX spec.
-		return iter->second.GetValue().compare("true") == 0;
-	}
+        // Note that we convert the value here ourselves in order to maintain
+        // compatibility with older versions of the TMX spec.
+        return iter->second.GetValue().compare("true") == 0;
+    }
 
     bool PropertySet::HasProperty( const string& name ) const
     {
@@ -123,15 +123,15 @@ namespace Tmx
         return ( properties.find(name) != properties.end() );
     }
 
-	std::map< std::string, std::string > PropertySet::GetList() const
-	{
-		std::map< std::string, std::string > orderedProperties;
-		for (auto &pair : properties)
-		{
-			auto &property = pair.second;
-			orderedProperties[pair.first] = property.GetValue();
-		}
-		return orderedProperties;
-	}
+    std::map< std::string, std::string > PropertySet::GetList() const
+    {
+        std::map< std::string, std::string > orderedProperties;
+        for (auto &pair : properties)
+        {
+            auto &property = pair.second;
+            orderedProperties[pair.first] = property.GetValue();
+        }
+        return orderedProperties;
+    }
 
 }

--- a/src/TmxPropertySet.h
+++ b/src/TmxPropertySet.h
@@ -27,8 +27,11 @@
 //-----------------------------------------------------------------------------
 #pragma once
 
+#include <unordered_map>
 #include <map>
 #include <string>
+
+#include "TmxProperty.h"
 
 namespace tinyxml2 {
     class XMLNode;
@@ -36,6 +39,8 @@ namespace tinyxml2 {
 
 namespace Tmx
 {
+	class Property;
+
     //-----------------------------------------------------------------------------
     // This class contains a map of properties.
     //-----------------------------------------------------------------------------
@@ -52,6 +57,8 @@ namespace Tmx
         int GetIntProperty(const std::string &name, int defaultValue = 0) const;
         // Get a float property.
         float GetFloatProperty(const std::string &name, float defaultValue = 0.0f) const;
+		// Get a boolean property.
+		bool GetBoolProperty(const std::string &name, bool defaultValue = false) const;
 
         // Get a string property. Returns "" if no value.
         std::string GetStringProperty(const std::string &name) const;
@@ -59,17 +66,22 @@ namespace Tmx
         // Returns the amount of properties.
         int GetSize() const { return properties.size(); }
 
+		// Checks if a property exists in the set.
         bool HasProperty( const std::string& name ) const;
 
+		// Returns the unordered map of properties.
+		const std::unordered_map< std::string, Property > &GetPropertyMap() const
+		{ return properties; }
+
         // Returns the STL map of the properties.
-        std::map< std::string, std::string > GetList() const
-        { return properties; }
+		// Deprecated, please use GetPropertyMap() instead.
+		std::map< std::string, std::string > GetList() const;
 
         // Returns whether there are no properties.
         bool Empty() const { return properties.empty(); }
 
     private:
-        std::map< std::string, std::string > properties;
+        std::unordered_map< std::string, Property > properties;
 
     };
 }

--- a/src/TmxPropertySet.h
+++ b/src/TmxPropertySet.h
@@ -39,7 +39,7 @@ namespace tinyxml2 {
 
 namespace Tmx
 {
-	class Property;
+    class Property;
 
     //-----------------------------------------------------------------------------
     // This class contains a map of properties.
@@ -57,8 +57,8 @@ namespace Tmx
         int GetIntProperty(const std::string &name, int defaultValue = 0) const;
         // Get a float property.
         float GetFloatProperty(const std::string &name, float defaultValue = 0.0f) const;
-		// Get a boolean property.
-		bool GetBoolProperty(const std::string &name, bool defaultValue = false) const;
+        // Get a boolean property.
+        bool GetBoolProperty(const std::string &name, bool defaultValue = false) const;
 
         // Get a string property. Returns "" if no value.
         std::string GetStringProperty(const std::string &name) const;
@@ -66,16 +66,16 @@ namespace Tmx
         // Returns the amount of properties.
         int GetSize() const { return properties.size(); }
 
-		// Checks if a property exists in the set.
+        // Checks if a property exists in the set.
         bool HasProperty( const std::string& name ) const;
 
-		// Returns the unordered map of properties.
-		const std::unordered_map< std::string, Property > &GetPropertyMap() const
-		{ return properties; }
+        // Returns the unordered map of properties.
+        const std::unordered_map< std::string, Property > &GetPropertyMap() const
+        { return properties; }
 
         // Returns the STL map of the properties.
-		// Deprecated, please use GetPropertyMap() instead.
-		std::map< std::string, std::string > GetList() const;
+        // Deprecated, please use GetPropertyMap() instead.
+        std::map< std::string, std::string > GetList() const;
 
         // Returns whether there are no properties.
         bool Empty() const { return properties.empty(); }

--- a/test/example/example.tmx
+++ b/test/example/example.tmx
@@ -1,6 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map version="1.0" orientation="orthogonal" renderorder="right-down" width="10" height="10" tilewidth="32" tileheight="32" nextobjectid="4">
- <tileset firstgid="1" name="tmw_desert_spacing" tilewidth="32" tileheight="32" spacing="1" margin="1">
+ <properties>
+  <property name="BigInteger" type="int" value="999999999"/>
+  <property name="EmptyProperty" value=""/>
+  <property name="FalseProperty" type="bool" value="false"/>
+  <property name="FloatProperty" type="float" value="0.12"/>
+  <property name="IntProperty" type="int" value="1234"/>
+  <property name="NegativeFloatProperty" type="float" value="-0.12"/>
+  <property name="NegativeIntProperty" type="int" value="-1234"/>
+  <property name="StringProperty" value="A string value"/>
+  <property name="TrueProperty" type="bool" value="true"/>
+ </properties>
+ <tileset firstgid="1" name="tmw_desert_spacing" tilewidth="32" tileheight="32" spacing="1" margin="1" tilecount="48" columns="8">
   <image source="tmw_desert_spacing.png" trans="ffffff" width="265" height="199"/>
   <tile id="0">
    <properties>
@@ -89,7 +100,7 @@
    </objectgroup>
   </tile>
  </tileset>
- <tileset firstgid="49" name="torches" tilewidth="32" tileheight="32">
+ <tileset firstgid="49" name="torches" tilewidth="32" tileheight="32" tilecount="3" columns="3">
   <image source="torches.png" width="96" height="32"/>
   <tile id="0">
    <objectgroup draworder="index">

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -24,6 +24,7 @@
 #include "Tmx.h"
 #include <cstdio>
 #include <cstdlib>
+#include <cassert>
 
 int main(int argc, char * argv[])
 {
@@ -57,6 +58,48 @@ int main(int argc, char * argv[])
     printf("Height: %d\n", map->GetHeight());
     printf("Tile Width: %d\n", map->GetTileWidth());
     printf("Tile Height: %d\n", map->GetTileHeight());
+
+    // Iterate through map properties and print the type, name and value of each property.
+    const std::unordered_map<std::string, Tmx::Property> &mapProperties = map->GetProperties().GetPropertyMap();
+    for (auto &pair : mapProperties)
+    {
+        auto &property = pair.second;
+
+        std::string type;
+
+        if (property.GetType() == Tmx::TMX_PROPERTY_STRING)
+        {
+            type = "String";
+        }
+        else if (property.GetType() == Tmx::TMX_PROPERTY_FLOAT)
+        {
+            type = "Float";
+        }
+        else if (property.GetType() == Tmx::TMX_PROPERTY_INT)
+        {
+            type = "Integer";
+        }
+        else if (property.GetType() == Tmx::TMX_PROPERTY_BOOL)
+        {
+            type = "Boolean";
+        }
+        else
+        {
+            type = "Unknown (string)";
+        }
+
+        printf("Map property %s (%s) = %s\n", pair.first.c_str(), type.c_str(),  property.GetValue().c_str());
+    }
+
+    // Make sure property parsing works correctly across the library.
+    assert(mapProperties.at("StringProperty").GetValue() == map->GetProperties().GetStringProperty("StringProperty"));
+    assert(mapProperties.at("IntProperty").GetIntValue() == map->GetProperties().GetIntProperty("IntProperty"));
+    assert(mapProperties.at("NegativeIntProperty").GetIntValue() == map->GetProperties().GetIntProperty("NegativeIntProperty"));
+    assert(mapProperties.at("FloatProperty").GetFloatValue() == map->GetProperties().GetFloatProperty("FloatProperty"));
+    assert(mapProperties.at("NegativeFloatProperty").GetFloatValue() == map->GetProperties().GetFloatProperty("NegativeFloatProperty"));
+    assert(mapProperties.at("BigInteger").GetIntValue() == map->GetProperties().GetIntProperty("BigInteger"));
+    assert(mapProperties.at("FalseProperty").GetBoolValue() == map->GetProperties().GetBoolProperty("FalseProperty"));
+    assert(mapProperties.at("TrueProperty").GetBoolValue() == map->GetProperties().GetBoolProperty("TrueProperty"));
 
     // Iterate through the tilesets.
     for (int i = 0; i < map->GetNumTilesets(); ++i)


### PR DESCRIPTION
Tiled version 0.16 introduced support for properties with types, these additions to the library add a way to access this type information.

In addition, `PropertySet` now uses an `unordered_map` instead of a `map` to store its properties (for faster access by key in large property sets.)
