### PR TITLE
Add C++11 requirement in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,8 @@ set(VERSION_MINOR 0)
 set(VERSION_PATCH 1)
 
 set(VERSION "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}")
+set(CMAKE_CXX_STANDARD 11)
+
 message("Configuring tmxparser version ${VERSION}")
 configure_file(
   "${PROJECT_SOURCE_DIR}/src/Tmx.h.in"


### PR DESCRIPTION
tmxparser did not build for me at first, stating that the compiler needed support for C++11. I'm using GCC 5.4.0.
I needed to add a C++11 flag to CMake to have it enable the flags for it. This does however require CMake 3.1, perhaps you don't want to add that requirement to your code.

I got the solution from here, there is a longer macro function to handle older CMake versions as well.

http://stackoverflow.com/a/31010221/791094
