### PR TITLE
Fixes #48 - Adds CMAKE_CXX_STANDARD flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
 set(VERSION_MAJOR 2)
 set(VERSION_MINOR 0)
 set(VERSION_PATCH 1)
-
+set (CMAKE_CXX_STANDARD 11)
 set(VERSION "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}")
 message("Configuring tmxparser version ${VERSION}")
 configure_file(


### PR DESCRIPTION
Ensures the right flags are used with cmake so that C++ 11 support is enabled.