### PR TITLE
Better compatibility with cmake project as subdirectory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.8)
 project(tmxparser)
-set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
+set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake ${CMAKE_MODULE_PATH})
 
 set(VERSION_MAJOR 2)
 set(VERSION_MINOR 0)


### PR DESCRIPTION
If tmxparser is being shipped withing a thirdparty project CMAKE_SOURCE_DIR will incorrectly point to the top folder of the project.
To be able to use tmxparser as a subdirectory this change is needed.
This is backwards compatible.