### PR TITLE
Add support for color and file property types (added in Tiled 0.17)

### DIFF
--- a/src/TmxColor.cpp
+++ b/src/TmxColor.cpp
@@ -1,0 +1,95 @@
+//-----------------------------------------------------------------------------
+// TmxColor.cpp
+//
+// Copyright (c) 2017, Guillaume Bertholon
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL TAMIR ATIAS BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Author: Guillaume Bertholon
+//-----------------------------------------------------------------------------
+#include "TmxColor.h"
+#include <cstdio>
+
+namespace Tmx
+{
+    Color::Color()
+        : color(0)
+    {
+    }
+
+    Color::Color(uint32_t c)
+        : color(c)
+    {
+    }
+
+    Color::Color(uint8_t r, uint8_t g, uint8_t b, uint8_t a)
+    {
+        color = 0;
+
+        color |= a;
+        color <<= 8;
+        color |= r;
+        color <<= 8;
+        color |= g;
+        color <<= 8;
+        color |= b;
+    }
+
+    Color::Color(const std::string& str)
+    {
+        // We skip the first # character and then read directly the hexadecimal value
+        color = std::strtol((str.c_str() + 1), nullptr, 16);
+
+        // If the input has the short format #RRGGBB without alpha channel we set it to 255
+        if(str.length() == 7) color |= 0xff000000;
+    }
+
+    Color::~Color()
+    {
+    }
+
+    uint8_t Color::GetAlpha() const
+    {
+        return (color & 0xff000000) >> 24;
+    }
+
+    uint8_t Color::GetRed() const
+    {
+        return (color & 0x00ff0000) >> 16;
+    }
+
+    uint8_t Color::GetGreen() const
+    {
+        return (color & 0x0000ff00) >> 8;
+    }
+
+    uint8_t Color::GetBlue() const
+    {
+        return (color & 0x000000ff);
+    }
+
+    std::string Color::ToString() const
+    {
+        char strRep[10];
+        std::sprintf(strRep, "#%.8x", color);
+        return std::string(strRep);
+    }
+}

--- a/src/TmxColor.h
+++ b/src/TmxColor.h
@@ -1,0 +1,74 @@
+//-----------------------------------------------------------------------------
+// TmxColor.h
+//
+// Copyright (c) 2017, Guillaume Bertholon
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL TAMIR ATIAS BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Author: Guillaume Bertholon
+//-----------------------------------------------------------------------------
+#pragma once
+
+#include <string>
+#include <cstdint>
+
+namespace Tmx
+{
+    //-------------------------------------------------------------------------
+    // A class used for storing information about a color
+    //-------------------------------------------------------------------------
+    class Color
+    {
+    public:
+        Color();
+        Color(uint32_t color);
+        Color(uint8_t r, uint8_t g, uint8_t b, uint8_t a = 255);
+        explicit Color(const std::string& str);
+        ~Color();
+
+        Color(const Color&) = default;
+        Color& operator=(const Color&) = default;
+
+        bool operator==(const Color& o) { return color == o.color; }
+        bool operator!=(const Color& o) { return color != o.color; }
+
+        // Get the alpha component of the color
+        uint8_t GetAlpha() const;
+
+        // Get the red component of the color
+        uint8_t GetRed() const;
+
+        // Get the green component of the color
+        uint8_t GetGreen() const;
+
+        // Get the blue component of the color
+        uint8_t GetBlue() const;
+
+        // Get the 32 bits integer representing the color. The 8 highest bits are for the alpha channel, then the red, the green and the blue.
+        uint32_t ToInt() const { return color; }
+
+        // Get a string representation of the color in the format #AARRGGBB
+        std::string ToString() const;
+
+    private:
+        uint32_t color;
+    };
+}

--- a/src/TmxProperty.cpp
+++ b/src/TmxProperty.cpp
@@ -38,11 +38,11 @@ namespace Tmx
 
     void Property::Parse(const tinyxml2::XMLElement *propertyElem)
     {
-        auto typeAttribute = propertyElem->FindAttribute("type");
+        const tinyxml2::XMLAttribute* typeAttribute = propertyElem->FindAttribute("type");
 
         if (typeAttribute != nullptr)
         {
-            auto typeAsCString = typeAttribute->Value();
+            const char* typeAsCString = typeAttribute->Value();
 
             if (strcmp(typeAsCString, "string") == 0)
             {
@@ -60,6 +60,14 @@ namespace Tmx
             {
                 type = TMX_PROPERTY_INT;
             }
+            else if (strcmp(typeAsCString, "color") == 0)
+            {
+                type = TMX_PROPERTY_COLOR;
+            }
+            else if (strcmp(typeAsCString, "file") == 0)
+            {
+                type = TMX_PROPERTY_FILE;
+            }
             else
             {
                 type = TMX_PROPERTY_STRING;
@@ -70,7 +78,7 @@ namespace Tmx
             type = TMX_PROPERTY_STRING;
         }
 
-        auto valueAsCString = propertyElem->Attribute("value");
+        const char* valueAsCString = propertyElem->Attribute("value");
         if (valueAsCString)
         {
             value = valueAsCString;

--- a/src/TmxProperty.h
+++ b/src/TmxProperty.h
@@ -28,6 +28,7 @@
 #pragma once
 
 #include <string>
+#include "TmxColor.h"
 
 namespace tinyxml2 {
     class XMLElement;
@@ -51,6 +52,12 @@ namespace Tmx
 
         // A floating point property
         TMX_PROPERTY_FLOAT,
+
+        // A color property
+        TMX_PROPERTY_COLOR,
+
+        // A file property
+        TMX_PROPERTY_FILE
     };
 
     //-------------------------------------------------------------------------
@@ -85,6 +92,8 @@ namespace Tmx
         // Convert the value to a float and return it (or the default value if not a float).
         float GetFloatValue(float defaultValue = 0.0f) const;
 
+        // Convert the value to a color and return it (or the default value if not a color).
+        Tmx::Color GetColorValue(Tmx::Color defaultValue = Tmx::Color()) const;
     private:
         PropertyType type;
         std::string value;
@@ -112,5 +121,13 @@ namespace Tmx
             return defaultValue;
 
         return std::stof(value);
+    }
+
+    inline Tmx::Color Property::GetColorValue(Tmx::Color defaultValue) const
+    {
+        if (!IsOfType(TMX_PROPERTY_COLOR))
+            return defaultValue;
+
+        return Tmx::Color(value);
     }
 }

--- a/src/TmxPropertySet.cpp
+++ b/src/TmxPropertySet.cpp
@@ -117,6 +117,16 @@ namespace Tmx
         return iter->second.GetValue().compare("true") == 0;
     }
 
+    Tmx::Color PropertySet::GetColorProperty(const string &name, Tmx::Color defaultValue) const
+    {
+        auto iter = properties.find(name);
+
+        if (iter == properties.end() || iter->second.IsValueEmpty())
+            return defaultValue;
+
+        return iter->second.GetColorValue(defaultValue);
+    }
+
     bool PropertySet::HasProperty( const string& name ) const
     {
         if( properties.empty() ) return false;

--- a/src/TmxPropertySet.h
+++ b/src/TmxPropertySet.h
@@ -59,8 +59,10 @@ namespace Tmx
         float GetFloatProperty(const std::string &name, float defaultValue = 0.0f) const;
         // Get a string property.
         std::string GetStringProperty(const std::string &name, std::string defaultValue = "") const;
-        // Get a string property.
+        // Get a bool property.
         bool GetBoolProperty(const std::string &name, bool defaultValue = false) const;
+        // Get a color property.
+        Tmx::Color GetColorProperty(const std::string &name, Tmx::Color defaultValue = Tmx::Color()) const;
 
         // Returns the amount of properties.
         int GetSize() const { return properties.size(); }

--- a/test/example/example.tmx
+++ b/test/example/example.tmx
@@ -4,12 +4,14 @@
   <property name="BigInteger" type="int" value="999999999"/>
   <property name="EmptyProperty" value=""/>
   <property name="FalseProperty" type="bool" value="false"/>
+  <property name="FileProperty" type="file" value="torches.png"/>
   <property name="FloatProperty" type="float" value="0.12"/>
   <property name="IntProperty" type="int" value="1234"/>
   <property name="NegativeFloatProperty" type="float" value="-0.12"/>
   <property name="NegativeIntProperty" type="int" value="-1234"/>
   <property name="StringProperty" value="A string value"/>
   <property name="TrueProperty" type="bool" value="true"/>
+  <property name="YellowProperty" type="color" value="#ffffff00"/>
  </properties>
  <tileset firstgid="1" name="tmw_desert_spacing" tilewidth="32" tileheight="32" spacing="1" margin="1" tilecount="48" columns="8">
   <image source="tmw_desert_spacing.png" trans="ffffff" width="265" height="199"/>

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -63,7 +63,7 @@ int main(int argc, char * argv[])
     const std::unordered_map<std::string, Tmx::Property> &mapProperties = map->GetProperties().GetPropertyMap();
     for (auto &pair : mapProperties)
     {
-        auto &property = pair.second;
+        const Tmx::Property &property = pair.second;
 
         std::string type;
 
@@ -83,9 +83,17 @@ int main(int argc, char * argv[])
         {
             type = "Boolean";
         }
+        else if (property.GetType() == Tmx::TMX_PROPERTY_COLOR)
+        {
+            type = "Color";
+        }
+        else if (property.GetType() == Tmx::TMX_PROPERTY_FILE)
+        {
+            type = "File";
+        }
         else
         {
-            type = "Unknown (string)";
+            type = "Unknown";
         }
 
         printf("Map property %s (%s) = %s\n", pair.first.c_str(), type.c_str(),  property.GetValue().c_str());
@@ -100,6 +108,12 @@ int main(int argc, char * argv[])
     assert(mapProperties.at("BigInteger").GetIntValue() == map->GetProperties().GetIntProperty("BigInteger"));
     assert(mapProperties.at("FalseProperty").GetBoolValue() == map->GetProperties().GetBoolProperty("FalseProperty"));
     assert(mapProperties.at("TrueProperty").GetBoolValue() == map->GetProperties().GetBoolProperty("TrueProperty"));
+    assert(mapProperties.at("YellowProperty").GetColorValue() == map->GetProperties().GetColorProperty("YellowProperty"));
+    assert(mapProperties.at("FileProperty").GetBoolValue() == map->GetProperties().GetBoolProperty("FileProperty"));
+
+    // Make sure color can be converted from and to string
+    assert(map->GetProperties().GetColorProperty("YellowProperty").ToString() == map->GetProperties().GetStringProperty("YellowProperty"));
+    assert(Tmx::Color("#ffffff") == Tmx::Color("#ffffffff"));
 
     // Iterate through the tilesets.
     for (int i = 0; i < map->GetNumTilesets(); ++i)


### PR DESCRIPTION
Add the Tmx::Color class to store colors and easily read their components
Update the example to include color related tests

This commit does not introduce any breaking change in the API even if it could be convenient to store all colors as Tmx::Color instead of std::string.