### PR TITLE
[FIX] Missing Header [IMP] Get tile by index

### DIFF
--- a/src/TmxTileLayer.h
+++ b/src/TmxTileLayer.h
@@ -29,6 +29,7 @@
 
 #include <string>
 
+#include "TmxLayer.h"
 #include "TmxPropertySet.h"
 #include "TmxMapTile.h"
 
@@ -100,6 +101,7 @@ namespace Tmx
 
         // Get a tile specific to the map.
         const Tmx::MapTile& GetTile(int x, int y) const { return tile_map[y * width + x]; }
+        const Tmx::MapTile& GetTile(int index) const { return tile_map[index]; }
 
         // Get the type of encoding that was used for parsing the tile layer data.
         // See: TileLayerEncodingType


### PR DESCRIPTION
Descriptive Title...

Without this PR:
- Get error if try compile with gcc because need a header.
- Can't get a specific tile without use nested loops or without convert 1D to 2D