### PR TITLE
TinyXML2 6.x has removed GetErrStr1, Additional Features, Memory Leak Fix

### DIFF
--- a/src/TmxLayer.cpp
+++ b/src/TmxLayer.cpp
@@ -48,6 +48,7 @@ namespace Tmx
 {
     Layer::Layer(const Tmx::Map *_map, const std::string _name, const int _x, const int _y, const int _width, const int _height, const float _opacity, const bool _visible, const LayerType _layerType) 
         : map(_map)
+				, tile(NULL)
         , name(_name)
         , x(_x)
         , y(_y)
@@ -62,7 +63,23 @@ namespace Tmx
     {
         ++nextParseOrder;
     }
-
+		Layer::Layer(const Tmx::Tile *_tile, const std::string _name, const int _x, const int _y, const int _width, const int _height, const float _opacity, const bool _visible, const LayerType _layerType) 
+        : map(NULL)
+				, tile(_tile)
+        , name(_name)
+        , x(_x)
+        , y(_y)
+        , width(_width)
+        , height(_height)
+        , opacity(_opacity)
+        , visible(_visible)
+        , zOrder(nextParseOrder)
+        , parseOrder(nextParseOrder)
+        , layerType(_layerType)
+        , properties()
+    {
+        ++nextParseOrder;
+    }
     Layer::~Layer() 
     {
     }

--- a/src/TmxLayer.h
+++ b/src/TmxLayer.h
@@ -39,7 +39,7 @@ namespace tinyxml2 {
 namespace Tmx 
 {
     class Map;
-
+		class Tile;
     enum LayerType
     {
         TMX_LAYERTYPE_TILE        = 0X01,
@@ -57,10 +57,14 @@ namespace Tmx
         Layer(const Layer &_layer);
 
     public:
-        /// Construct a new Layer.
+        /// Construct a new Layer used by a map's objectgroup
         Layer(const Tmx::Map *_map, const std::string _name, const int _x, const int _y,
               const int _width, const int _height, const float _opacity, const bool _visible, const LayerType _layerType);
-
+							
+				/// Construct a new layer used by a tile's objectgroup
+				Layer(const Tmx::Tile *_tile, const std::string _name, const int _x, const int _y,
+              const int _width, const int _height, const float _opacity, const bool _visible, const LayerType _layerType);
+							
         virtual ~Layer();
 
         /// Parse a layer element.
@@ -108,7 +112,7 @@ namespace Tmx
     protected:
         /// @cond INTERNAL
         const Tmx::Map *map;
-
+				const Tmx::Tile *tile;
         std::string name;
         
         int x;

--- a/src/TmxMap.cpp
+++ b/src/TmxMap.cpp
@@ -38,9 +38,9 @@
 using std::vector;
 using std::string;
 
-namespace Tmx 
+namespace Tmx
 {
-    Map::Map() 
+    Map::Map()
         : file_name()
         , file_path()
         , background_color()
@@ -58,20 +58,20 @@ namespace Tmx
         , layers()
         , tile_layers()
         , object_groups()
-        , tilesets() 
+        , tilesets()
         , has_error(false)
         , error_code(0)
         , error_text()
     {}
 
-    Map::~Map() 
+    Map::~Map()
     {
         // Iterate through all of the object groups and delete each of them.
         vector< ObjectGroup* >::iterator ogIter;
-        for (ogIter = object_groups.begin(); ogIter != object_groups.end(); ++ogIter) 
+        for (ogIter = object_groups.begin(); ogIter != object_groups.end(); ++ogIter)
         {
             ObjectGroup *objectGroup = (*ogIter);
-            
+
             if (objectGroup)
             {
                 delete objectGroup;
@@ -81,11 +81,11 @@ namespace Tmx
 
         // Iterate through all of the tile layers and delete each of them.
         vector< TileLayer* >::iterator tlIter;
-        for (tlIter = tile_layers.begin(); tlIter != tile_layers.end(); ++tlIter) 
+        for (tlIter = tile_layers.begin(); tlIter != tile_layers.end(); ++tlIter)
         {
             TileLayer *layer = (*tlIter);
 
-            if (layer) 
+            if (layer)
             {
                 delete layer;
                 layer = NULL;
@@ -94,11 +94,11 @@ namespace Tmx
 
         // Iterate through all of the image layers and delete each of them.
         vector< ImageLayer* >::iterator ilIter;
-        for (ilIter = image_layers.begin(); ilIter != image_layers.end(); ++ilIter) 
+        for (ilIter = image_layers.begin(); ilIter != image_layers.end(); ++ilIter)
         {
             ImageLayer *layer = (*ilIter);
 
-            if (layer) 
+            if (layer)
             {
                 delete layer;
                 layer = NULL;
@@ -107,11 +107,11 @@ namespace Tmx
 
         // Iterate through all of the tilesets and delete each of them.
         vector< Tileset* >::iterator tsIter;
-        for (tsIter = tilesets.begin(); tsIter != tilesets.end(); ++tsIter) 
+        for (tsIter = tilesets.begin(); tsIter != tilesets.end(); ++tsIter)
         {
             Tileset *tileset = (*tsIter);
-            
-            if (tileset) 
+
+            if (tileset)
             {
                 delete tileset;
                 tileset = NULL;
@@ -119,18 +119,18 @@ namespace Tmx
         }
     }
 
-    void Map::ParseFile(const string &fileName) 
+    void Map::ParseFile(const string &fileName)
     {
         file_name = fileName;
 
         int lastSlash = fileName.find_last_of("/");
 
         // Get the directory of the file using substring.
-        if (lastSlash > 0) 
+        if (lastSlash > 0)
         {
             file_path = fileName.substr(0, lastSlash + 1);
-        } 
-        else 
+        }
+        else
         {
             file_path = "";
         }
@@ -144,7 +144,7 @@ namespace Tmx
         {
             has_error = true;
             error_code = TMX_PARSING_ERROR;
-            error_text = doc.GetErrorStr1();
+            error_text = doc.ErrorStr();
             return;
         }
 
@@ -152,18 +152,18 @@ namespace Tmx
         Parse( mapNode );
     }
 
-    void Map::ParseText(const string &text) 
+    void Map::ParseText(const string &text)
     {
         // Create a tiny xml document and use it to parse the text.
         tinyxml2::XMLDocument doc;
         doc.Parse(text.c_str());
-    
+
         // Check for parsing errors.
-        if (doc.Error()) 
+        if (doc.Error())
         {
             has_error = true;
             error_code = TMX_PARSING_ERROR;
-            error_text = doc.GetErrorStr1();
+            error_text = doc.ErrorStr();
             return;
         }
 
@@ -176,29 +176,29 @@ namespace Tmx
         // Clean up the flags from the gid (thanks marwes91).
         gid &= ~(FlippedHorizontallyFlag | FlippedVerticallyFlag | FlippedDiagonallyFlag);
 
-        for (int i = tilesets.size() - 1; i > -1; --i) 
+        for (int i = tilesets.size() - 1; i > -1; --i)
         {
             // If the gid beyond the tileset gid return its index.
-            if (gid >= tilesets[i]->GetFirstGid()) 
+            if (gid >= tilesets[i]->GetFirstGid())
             {
                 return i;
             }
         }
-        
+
         return -1;
     }
 
-    const Tileset *Map::FindTileset(int gid) const 
+    const Tileset *Map::FindTileset(int gid) const
     {
-        for (int i = tilesets.size() - 1; i > -1; --i) 
+        for (int i = tilesets.size() - 1; i > -1; --i)
         {
             // If the gid beyond the tileset gid return it.
-            if (gid >= tilesets[i]->GetFirstGid()) 
+            if (gid >= tilesets[i]->GetFirstGid())
             {
                 return tilesets[i];
             }
         }
-        
+
         return NULL;
     }
 
@@ -225,7 +225,7 @@ namespace Tmx
         if (!orientationStr.compare("orthogonal"))
         {
             orientation = TMX_MO_ORTHOGONAL;
-        } 
+        }
         else if (!orientationStr.compare("isometric"))
         {
             orientation = TMX_MO_ISOMETRIC;
@@ -243,22 +243,22 @@ namespace Tmx
         if (mapElem->Attribute("renderorder"))
         {
             std::string renderorderStr = mapElem->Attribute("renderorder");
-            if (!renderorderStr.compare("right-down")) 
+            if (!renderorderStr.compare("right-down"))
             {
                 render_order = TMX_RIGHT_DOWN;
-            } 
-            else if (!renderorderStr.compare("right-up")) 
+            }
+            else if (!renderorderStr.compare("right-up"))
             {
                 render_order = TMX_RIGHT_UP;
             }
-            else if (!renderorderStr.compare("left-down")) 
+            else if (!renderorderStr.compare("left-down"))
             {
                 render_order = TMX_LEFT_DOWN;
             }
-            else if (!renderorderStr.compare("left-down")) 
+            else if (!renderorderStr.compare("left-down"))
             {
                 render_order = TMX_LEFT_UP;
-            }        
+            }
         }
 
         // Read the stagger axis
@@ -302,7 +302,7 @@ namespace Tmx
             // Read the map properties.
             if( strcmp( node->Value(), "properties" ) == 0 )
             {
-                properties.Parse(node);         
+                properties.Parse(node);
             }
 
             // Iterate through all of the tileset elements.
@@ -316,7 +316,7 @@ namespace Tmx
                 tilesets.push_back(tileset);
             }
 
-            // Iterate through all of the "layer" (tile layer) elements.           
+            // Iterate through all of the "layer" (tile layer) elements.
             if( strcmp( node->Value(), "layer" ) == 0 )
             {
                 // Allocate a new tile layer and parse it.
@@ -328,7 +328,7 @@ namespace Tmx
                 layers.push_back(tileLayer);
             }
 
-            // Iterate through all of the "imagelayer" (image layer) elements.            
+            // Iterate through all of the "imagelayer" (image layer) elements.
             if( strcmp( node->Value(), "imagelayer" ) == 0 )
             {
                 // Allocate a new image layer and parse it.
@@ -346,7 +346,7 @@ namespace Tmx
                 // Allocate a new object group and parse it.
                 ObjectGroup *objectGroup = new ObjectGroup(this);
                 objectGroup->Parse(node);
-        
+
                 // Add the object group to the lists.
                 object_groups.push_back(objectGroup);
                 layers.push_back(objectGroup);

--- a/src/TmxObjectGroup.cpp
+++ b/src/TmxObjectGroup.cpp
@@ -39,6 +39,12 @@ namespace Tmx
         , objects()
     {}
 
+		ObjectGroup::ObjectGroup(const Tmx::Tile *_tile)
+        : Layer(_tile, std::string(), 0, 0, 0, 0, 1.0f, true, TMX_LAYERTYPE_OBJECTGROUP)
+        , color()
+        , objects()
+    {}
+			
     ObjectGroup::~ObjectGroup() 
     {
         for(std::size_t i = 0; i < objects.size(); i++)
@@ -52,8 +58,8 @@ namespace Tmx
     {
         const tinyxml2::XMLElement *objectGroupElem = objectGroupNode->ToElement();
 
-        // Read the object group attributes.
-        name = objectGroupElem->Attribute("name");
+        // Read the object group attributes, set to unknown if not defined in XML
+				objectGroupElem->Attribute("name") != NULL ? name = objectGroupElem->Attribute("name"): name = "unknown";
 
         if (objectGroupElem->Attribute("color"))
         {

--- a/src/TmxObjectGroup.h
+++ b/src/TmxObjectGroup.h
@@ -51,6 +51,9 @@ namespace Tmx
         /// Construct a new ObjectGroup
         ObjectGroup(const Tmx::Map *_map);
 
+				/// Construct a new ObjectGroup used by a Tile
+				ObjectGroup(const Tmx::Tile *_tile);
+				
         ~ObjectGroup();
 
         /// Parse an objectgroup node.
@@ -67,10 +70,14 @@ namespace Tmx
 
         /// Get the whole list of objects.
         const std::vector< Tmx::Object* > &GetObjects() const { return objects; }
+				
+				/// Get the property set.
+				const Tmx::PropertySet &GetProperties() const { return properties; }
 
     private:
         Tmx::Color color;
 
         std::vector< Tmx::Object* > objects;
+				Tmx::PropertySet properties;
     };
 }

--- a/src/TmxPropertySet.cpp
+++ b/src/TmxPropertySet.cpp
@@ -70,7 +70,7 @@ namespace Tmx
             propertyNode = propertyNode->NextSiblingElement("property");
         }
     }
-
+		
     string PropertySet::GetStringProperty(const string &name, string defaultValue) const
     {
         std::unordered_map< string, Property >::const_iterator iter = properties.find(name);

--- a/src/TmxPropertySet.h
+++ b/src/TmxPropertySet.h
@@ -52,7 +52,6 @@ namespace Tmx
 
         /// Parse a node containing all the property nodes.
         void Parse(const tinyxml2::XMLNode *propertiesNode);
-
         /// Get a int property.
         int GetIntProperty(const std::string &name, int defaultValue = 0) const;
         /// Get a float property.

--- a/src/TmxTile.cpp
+++ b/src/TmxTile.cpp
@@ -33,11 +33,11 @@
 namespace Tmx
 {
     Tile::Tile() :
-            id(0), properties(), isAnimated(false),hasObjects(false), totalDuration(0), image(NULL)
+            id(0), properties(), isAnimated(false), hasObjects(false), hasObjectGroup(false), objectGroup(NULL), totalDuration(0), image(NULL)
     {
     }
     Tile::Tile(int id) :
-            id(id), properties(), isAnimated(false),hasObjects(false), totalDuration(0), image(NULL)
+            id(id), properties(), isAnimated(false), hasObjects(false), hasObjectGroup(false), objectGroup(NULL), totalDuration(0), image(NULL)
     {
     }
 
@@ -48,6 +48,11 @@ namespace Tmx
             delete image;
             image = NULL;
         }
+				if (objectGroup)
+				{
+					delete objectGroup;
+					objectGroup = NULL;
+				}
     }
 
     void Tile::Parse(const tinyxml2::XMLNode *tileNode)
@@ -95,27 +100,17 @@ namespace Tmx
 
             totalDuration = durationSum;
         }
-
-        const tinyxml2::XMLNode *collisionNode = tileNode->FirstChildElement(
+				
+        const tinyxml2::XMLNode *objectGroupNode = tileNode->FirstChildElement(
                 "objectgroup");
-        if (collisionNode)
+        if (objectGroupNode)
         {
-            const tinyxml2::XMLNode *objectNode =
-                    collisionNode->FirstChildElement("object");
-            hasObjects = true;
-
-            while (objectNode != NULL)
-            {
-                const tinyxml2::XMLElement *objectElement =
-                        objectNode->ToElement();
-
-                Object *object = new Object();
-                object->Parse(objectElement);
-
-                objects.push_back(object);
-
-                objectNode = objectNode->NextSiblingElement("object");
-            }
+						hasObjectGroup = true;
+						//let's only create objectGroup if it's needed, save memory
+						objectGroup = new ObjectGroup(this);
+						objectGroup->Parse(objectGroupNode);
+						if (objectGroup->GetNumObjects() > 0) hasObjects = true;
+						
         }
 
         const tinyxml2::XMLNode *imageNode = tileNode->FirstChildElement("image");

--- a/src/TmxTile.h
+++ b/src/TmxTile.h
@@ -27,6 +27,8 @@
 
 #include "TmxPropertySet.h"
 #include "TmxImage.h"
+#include "TmxObjectGroup.h"
+#include <stdexcept>
 
 namespace tinyxml2
 {
@@ -98,11 +100,25 @@ namespace Tmx
         {
             return properties;
         }
-
-        /// Get set of Collision Objects
+				
+				//// Get the object group, which contains additional tile properties
+				const Tmx::ObjectGroup *GetObjectGroup() const
+				{
+						return objectGroup;
+				}
+				
+				//// Get the object group's properties, convenience function
+				const Tmx::PropertySet &GetObjectGroupProperties() const
+				{
+						if (!objectGroup) throw std::runtime_error ("Tile has no ObjectGroup on attempt to get ObjectGroup properties.  Cannot return null ref.");
+						return objectGroup->GetProperties();
+				}
+				
+        /// Get set of Collision Objects, convenience function
         std::vector<Tmx::Object*> GetObjects() const
         {
-            return objects;
+						if (!objectGroup) throw std::out_of_range ("Tile has no objectGroup");
+            return objectGroup->GetObjects();
         }
 
         /// Returns true if tile has Collision Objects
@@ -114,13 +130,15 @@ namespace Tmx
         /// Get a single object.
         const Tmx::Object *GetObject(int index) const
         {
-            return objects.at(index);
+						if (!objectGroup) throw std::out_of_range ("Tile has no objectGroup");
+            return objectGroup->GetObject(index);
         }
 
         /// Get the number of objects in the list.
         int GetNumObjects() const
         {
-            return objects.size();
+						if (!objectGroup) throw std::out_of_range ("Tile has no objectGroup");
+            return objectGroup->GetNumObjects();
         }
 
     private:
@@ -130,7 +148,8 @@ namespace Tmx
 
         bool isAnimated;
         bool hasObjects;
-        std::vector<Tmx::Object*> objects;
+				bool hasObjectGroup;
+				Tmx::ObjectGroup *objectGroup;
         unsigned int totalDuration;
         std::vector<AnimationFrame> frames;
         Tmx::Image* image;


### PR DESCRIPTION
894ca71) TinyXML2 6.x has removed GetErrStr1.  
Seems to be replaced with ErrorStr.  Consider this patch or consider importing a local copy of TinyXML2 and statically linking with your library?

0f16efb) Tile does not contain Objects.  It contains an ObjectGroup that contains Objects per TMX spec.
Without breaking your API, I made an attempt to restructure the class's inner workings a bit.   Should make fixing issue #51 trivial, which I'll do if this gets accepted upstream.  Need further discussion?  Kind of a design thing, if you want to accept it vs continue down the path of consolidating data in TmxTile.  The patch I have should not break any compatibility the way I did it.

Also, fixes a memory leak.  Objects are being allocated in TmxTile.cpp without being deleted.

Also fixes a segfault.  An ObjectGroup might not always have a "name" property.  

 