### PR TITLE
fix: Clean up shadow declaration warning

### DIFF
--- a/src/TmxProperty.h
+++ b/src/TmxProperty.h
@@ -75,7 +75,7 @@ namespace Tmx
         PropertyType GetType() const { return type; }
 
         /// Check if the property is of a certain type.
-        bool IsOfType(PropertyType type) const { return GetType() == type; }
+        bool IsOfType(PropertyType propertyType) const { return GetType() == propertyType; }
 
         /// Return the value of the property.
         const std::string &GetValue() const { return value; }


### PR DESCRIPTION
Since `type` is already defined as a private property, using its name was causing a shadow declaration warning. Renaming the attribute silences it.