### PR TITLE
Add vcpkg information to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ An example file is provided to understand how to use the library.
  * TinyXML2 >= 6.0.0
 
 ## Installation
-
+tmxparser uses CMake, and the standard CMake build flow works as you'd expect. It's also alternatively available in [vcpkg](https://github.com/Microsoft/vcpkg).
 ```
 mkdir build
 cd build


### PR DESCRIPTION
I've recently landed a PR in [vcpkg](https://github.com/Microsoft/vcpkg/pull/4512) which adds tmxparser support to vcpkg. I figured it would be good to add this info to the README - it makes it quite easy to get started using the library if you're already depending on vcpkg for other things such as SDL2 :)