### PR TITLE
Makes subdirectory use viable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ option(BUILD_TESTS  "Build tests. (default: OFF)" OFF)
 option(BUILD_DOCS  "Build documentation. (default: OFF)" OFF)
 
 #Dependencies Settings
-include(${CMAKE_SOURCE_DIR}/cmake/deps.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/deps.cmake)
 
 find_package(tinyxml2 REQUIRED)
 


### PR DESCRIPTION
Switches from use of CMAKE_SOURCE_DIR to CMAKE_CURRENT_SURCE_DIR.

This allows users to drop the project in as a subdirectory in their own
project. Allowing use of the CMake macro "add_subdirectory" without
build warnings.