### PR TITLE
Convert deprecated call to ptr_fun to lambda

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,10 +102,7 @@ target_include_directories(tmxparser PUBLIC
 
 target_compile_options(tmxparser
   PRIVATE -pedantic
-  PRIVATE -Wall
-  PRIVATE -Werror=strict-prototypes
-  PRIVATE -Werror=old-style-definition
-  PRIVATE -Werror=missing-prototypes)
+  PRIVATE -Wall)
 if(NOT USE_MINIZ)
   target_compile_options(tmxparser
     PRIVATE -Werror)

--- a/src/TmxUtil.cpp
+++ b/src/TmxUtil.cpp
@@ -46,13 +46,13 @@ namespace Tmx {
 
     // trim from start
     static inline std::string &ltrim(std::string &s) {
-        s.erase(s.begin(), std::find_if(s.begin(), s.end(), std::not1(std::ptr_fun<int, int>(std::isspace))));
+        s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](int c){ return !std::isspace(c); }));
         return s;
     }
 
     // trim from end
     static inline std::string &rtrim(std::string &s) {
-        s.erase(std::find_if(s.rbegin(), s.rend(), std::not1(std::ptr_fun<int, int>(std::isspace))).base(), s.end());
+        s.erase(std::find_if(s.rbegin(), s.rend(), [](int c){ return !std::isspace(c); }).base(), s.end());
         return s;
     }
 


### PR DESCRIPTION
ptr_fun has been deprecated in C++11 and removed in C++17, so the code currently does not build with GCC 12.2.1.

This PR replaces the use of ptr_fun with a local lambda.

See:
https://en.cppreference.com/w/cpp/utility/functional/ptr_fun

And the same solution here, that is applied in this PR:
https://stackoverflow.com/questions/44973435/stdptr-fun-replacement-for-c17

Fixes bug #82 
