### PR TITLE
Remove build flags that are redundant for C++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,10 +102,7 @@ target_include_directories(tmxparser PUBLIC
 
 target_compile_options(tmxparser
   PRIVATE -pedantic
-  PRIVATE -Wall
-  PRIVATE -Werror=strict-prototypes
-  PRIVATE -Werror=old-style-definition
-  PRIVATE -Werror=missing-prototypes)
+  PRIVATE -Wall)
 if(NOT USE_MINIZ)
   target_compile_options(tmxparser
     PRIVATE -Werror)


### PR DESCRIPTION
The redundant build flags are:
strict-prototypes, missing-prototypes, old-style-definition

GCC generates a build-warning if using them, which results in a build error since the -Werror flag is set.

See SO-answer regarding the flags being redundant for C++ here:
https://stackoverflow.com/a/6699884/791094

Fixes #79 